### PR TITLE
feat: Add ChangeAvailability command handling and simulation settings.

### DIFF
--- a/src/Components/Main/Main.jsx
+++ b/src/Components/Main/Main.jsx
@@ -270,6 +270,37 @@ const Main = () => {
           centralSystemSend(result.ocppCommand, result.lastCommand)
         }
         break;
+      case 'ChangeAvailability':
+        // Validate connectorId
+        if (connId === 0 || connId > settingsState.mainSettings.numberOfConnectors) {
+          const errorResponse = JSON.stringify([ 4, id, 'PropertyConstraintViolation', 'Invalid connectorId', {} ])
+          updateLog({ time: getTime(), type: logTypes.send, command: 'ChangeAvailability Error', message: errorResponse })
+          ws.send(errorResponse)
+          return
+        }
+
+        const { type } = payload
+        const changeAvailabilityStatus = settingsState.simulation.changeAvailabilityResponse
+        const changeAvailabilityResponse = JSON.stringify([ 3, id, { status: changeAvailabilityStatus }])
+        
+        updateLog({ time: getTime(), type: logTypes.send, command: 'ChangeAvailability Response', message: changeAvailabilityResponse })
+        ws.send(changeAvailabilityResponse)
+
+        // Send StatusNotification based on the response
+        if (changeAvailabilityStatus === 'Accepted' || changeAvailabilityStatus === 'Scheduled') {
+          // Determine the new status based on the type requested
+          const newStatus = type === 'Operative' ? connectorStatus.Available : connectorStatus.Unavailable
+          
+          // Change specific connector
+          if (!connectors[connId].inTransaction || changeAvailabilityStatus === 'Scheduled') {
+            connectors[connId].status = newStatus
+            updateConnector[connId]({ ...connectors[connId] })
+            
+            const statusData = sendCommand('StatusNotification', { connectorId: connId, status: newStatus })
+            centralSystemSend(statusData.ocppCommand, statusData.lastCommand)
+          }
+        }
+        break;
       default:
         break;
     }

--- a/src/Components/Settings/Simulation.jsx
+++ b/src/Components/Settings/Simulation.jsx
@@ -126,34 +126,77 @@ const Simulation = () => {
                   </FormControl>
                 : null
             }
+            <FormControl fullWidth>
+              <InputLabel>Change Availability Response</InputLabel>
+              <Select
+                size="small"
+                value={settingsState.simulation.changeAvailabilityResponse}
+                label="Change Availability Response"
+                name="changeAvailabilityResponse"
+                onChange={(e) =>
+                  changeValueAndInfo(e.target.name, e.target.value)
+                }
+                onMouseDown={() =>
+                  setHelpText({
+                    description:
+                      simulateInfo.changeAvailabilityResponse.description,
+                    valueDescription:
+                      simulateInfo.changeAvailabilityResponse.valueDescription[
+                        settingsState.simulation.changeAvailabilityResponse
+                      ],
+                    value: "changeAvailabilityResponse",
+                  })
+                }
+              >
+                <MenuItem value={"Accepted"}>Accepted</MenuItem>
+                <MenuItem value={"Rejected"}>Rejected</MenuItem>
+                <MenuItem value={"Scheduled"}>Scheduled</MenuItem>
+              </Select>
+            </FormControl>
           </Stack>
         </Grid>
         <Grid item xs={6}>
-          {
-            helpText === null
-            ? null
-            : <Paper sx={{p: 2}}>
-                <Box display='flex' alignItems='center' justifyContent='space-between'>
-                  <Typography fontWeight='bold' color='primary'>{helpText.value}</Typography>
-                  <HelpIcon color='primary' />
+          {helpText === null ? null : (
+            <Paper sx={{ p: 2 }}>
+              <Box
+                display="flex"
+                alignItems="center"
+                justifyContent="space-between"
+              >
+                <Typography fontWeight="bold" color="primary">
+                  {helpText.value}
+                </Typography>
+                <HelpIcon color="primary" />
+              </Box>
+              <Divider sx={{ mt: 0.5, mb: 1.5 }} />
+              <Stack direction="row" spacing={2} sx={{ pb: 1 }}>
+                <Box sx={{ minWidth: 80 }}>
+                  <Typography color="primary">Field desc:</Typography>
                 </Box>
-                <Divider sx={{ mt: 0.5, mb: 1.5 }} />
-                <Stack direction='row' spacing={2} sx={{pb: 1}} >
-                  <Box sx={{ minWidth: 80 }}><Typography color='primary'>Field desc:</Typography></Box>
-                  <Box>{ helpText.description }</Box>
-                </Stack>
-                <Stack direction='row' spacing={2} >
-                  {
-                    helpText.valueDescription
-                      ? <><Box sx={{ minWidth: 80 }}><Typography color='primary'>Value desc:</Typography></Box><Box>{ helpText.valueDescription }</Box></>
-                      : null
-                  }
-                </Stack>
-              </Paper>
-          }
+                <Box>{helpText.description}</Box>
+              </Stack>
+              <Stack direction="row" spacing={2}>
+                {helpText.valueDescription ? (
+                  <>
+                    <Box sx={{ minWidth: 80 }}>
+                      <Typography color="primary">Value desc:</Typography>
+                    </Box>
+                    <Box>{helpText.valueDescription}</Box>
+                  </>
+                ) : null}
+              </Stack>
+            </Paper>
+          )}
         </Grid>
       </Grid>
-      <Button sx={{mt: 3}} startIcon={<SaveIcon />} variant='contained' onClick={() => saveSettings(settingsState)}>Save</Button>
+      <Button
+        sx={{ mt: 3 }}
+        startIcon={<SaveIcon />}
+        variant="contained"
+        onClick={() => saveSettings(settingsState)}
+      >
+        Save
+      </Button>
     </Box>
   )
 }

--- a/src/Config/default-settings.js
+++ b/src/Config/default-settings.js
@@ -33,7 +33,8 @@ const defaultSettings = {
     firmWareStatus: 'Downloaded',
     connectorOneUnlock: 'Unlocked',
     connectorTwoUnlock: 'Unlocked',
-  }
-}
+    changeAvailabilityResponse: 'Accepted',
+  },
+};
 
 export default defaultSettings

--- a/src/common/help-texts.js
+++ b/src/common/help-texts.js
@@ -95,7 +95,16 @@ export const simulateInfo = {
     valueDescription: {
       Unlocked: 'Connector has successfully been unlocked.',
       UnlockFailed: 'Failed to unlock the connector',
-    }
-  }
-  
-}
+    },
+  },
+
+  changeAvailabilityResponse: {
+    description: `What status to return when Central System requests to change availability of the charge point or a connector.`,
+    valueDescription: {
+      Accepted: "Request has been accepted and will be executed.",
+      Rejected: "Request has not been accepted and will not be executed.",
+      Scheduled:
+        "Request has been accepted and will be executed when transaction(s) in progress have finished.",
+    },
+  },
+};


### PR DESCRIPTION
# Add ChangeAvailability Request Support

## Summary
Adds support for OCPP 1.6 `ChangeAvailability` requests with configurable response behavior.

## Changes
- **New Setting**: `changeAvailabilityResponse` in Simulation settings (Accepted/Rejected/Scheduled)
- **Request Handler**: Validates connectorId and sends appropriate response
- **StatusNotification**: Automatically sent after Accepted/Scheduled responses
  - `Operative` → `Available` status
  - `Inoperative` → `Unavailable` status
- **Error Handling**: Returns OCPP error for invalid connectorId (0 or out of range)

## Testing
1. Go to Settings → Simulation tab
2. Select desired response type
3. Send ChangeAvailability request from Central System
4. Verify response and StatusNotification in log

## OCPP Compliance
Fully compliant with OCPP 1.6 ChangeAvailability specification.